### PR TITLE
integrate SEDs for many redshifts and multiple filters

### DIFF
--- a/forward/mag.py
+++ b/forward/mag.py
@@ -1,31 +1,31 @@
 import numpy as np
 
 def integrate_sed(z, le, fe, lx, Rx, extinction=None):
-  '''Integrate one or many redshifted SEDs against filter bands.
+  '''Integrate redshifted SED against filter band.
 
   Arguments:
-  z (float or array-like): redshift values for observed SEDs
-  le (array or list of arrays): emitted wavelength λ_e of SEDs
-  fe (array or list of arrays): emitted function values f_e(λ_e) of SEDs
-  lx (array of float): filter wavelength λ_x
-  Rx (array of float): filter response values R_x(λ_x)
+  z (number or array-like): redshift values for observed SED
+  le (array-like): emitted wavelength λ_e of SED
+  fe (array-like): emitted function values f_e(λ_e) of SED
+  lx (array-like): filter wavelength λ_x
+  Rx (array-like): filter response values R_x(λ_x)
 
   Returns:
-  array with shape (number of SEDs, number of redshifts)
+  integral of (redshifted SED)*(filter pass) over observed wavelength
   '''
 
   if extinction is not None:
     raise NotImplementedError('cannot handle extinction')
 
-  if len(np.shape(z)) > 1:
+  if np.ndim(z) > 1:
     raise ValueError('redshift z must be 1d array or scalar')
 
-  if len(np.shape(lx)) != 1 or len(np.shape(Rx)) != 1:
+  if np.ndim(lx) != 1 or np.ndim(Rx) != 1:
       raise ValueError('filter lx, Rx must be 1d arrays')
 
   lo = np.expand_dims(le, -1)*np.add(z, 1)
   fo = np.expand_dims(fe, -1)
-  Ro = np.apply_along_axis(lambda l: np.interp(l, lx, Rx, left=0., right=0.), -1, lo)
+  Ro = np.interp(lo, lx, Rx, left=0., right=0.)
 
   result = np.trapz(lo*fo*Ro, lo, axis=-2)
 

--- a/forward/mag.py
+++ b/forward/mag.py
@@ -13,7 +13,7 @@ def abflux(z, le, fe, lx, Rx, extinction=None):
   lo = le*(1 + np.atleast_1d(z))
   Ro = np.interp(lo, lx, Rx, left=0, right=0)
 
-  result = np.trapz(lo*fe*Ro, le, axis=-2)/np.trapz(lo*Ro, lo, axis=-2)
+  result = np.trapz(lo*fe*Ro, le, axis=-2)/np.trapz(Ro/lo, lo, axis=-2)
 
   return result
 

--- a/forward/mag.py
+++ b/forward/mag.py
@@ -18,8 +18,10 @@ def abflux(z, le, fe, lx, Rx, extinction=None):
   return result
 
 
-def abmag(z, le, fe, lx, Rx, cosmology, extinction=None):
-  '''Compute apparent magnitude at source redshifts from SEDs and filters.
+def abmag(z, le, fe, lx, Rx, extinction=None):
+  '''Compute magnitude at source redshifts from SEDs and filters.
+
+  Does not include the cosmological scaling with (10pc/d_L)^2.
 
   Arguments:
   z (number or array): redshift values for observed SED
@@ -58,9 +60,6 @@ def abmag(z, le, fe, lx, Rx, cosmology, extinction=None):
     lx = it.repeat(lx)
   if np.ndim(Rx[0]) == 0:
     Rx = np.expand_dims(Rx, 0)
-
-  # compute the scaling with redshift
-  scale = 1/(cosmology.luminosity_distance(z).value*100+1)**2
 
   # compute AB fluxes for all bands and SEDs
   fluxes = [

--- a/forward/mag.py
+++ b/forward/mag.py
@@ -1,18 +1,20 @@
 import numpy as np
 
-def integrate_sed(z, λe, fe, λx, Rx, extinction=None):
+def integrate_sed(z, le, fe, lx, Rx, extinction=None):
   if extinction is not None:
     raise NotImplementedError('cannot handle extinction')
 
   if len(np.shape(z)) > 1:
     raise ValueError('redshift z must be 1d array or scalar')
 
-  if len(np.shape(λx)) != 1 or len(np.shape(Rx)) != 1:
-      raise ValueError('filter λx, Rx must be 1d arrays')
+  if len(np.shape(lx)) != 1 or len(np.shape(Rx)) != 1:
+      raise ValueError('filter lx, Rx must be 1d arrays')
 
-  λo = np.expand_dims(λe, -1)*np.add(z, 1)
+  lo = np.expand_dims(le, -1)*np.add(z, 1)
   fo = np.expand_dims(fe, -1)
-  Ro = np.apply_along_axis(lambda λ: np.interp(λ, λx, Rx), -1, λo)
+  Ro = np.apply_along_axis(lambda l: np.interp(l, lx, Rx), -1, lo)
 
-  return np.trapz(λo*fo*Ro, λo, axis=-2)
+  result = np.trapz(lo*fo*Ro, lo, axis=-2)
+
+  return result
 

--- a/forward/mag.py
+++ b/forward/mag.py
@@ -1,6 +1,19 @@
 import numpy as np
 
 def integrate_sed(z, le, fe, lx, Rx, extinction=None):
+  '''Integrate one or many redshifted SEDs against filter bands.
+
+  Arguments:
+  z (float or array-like): redshift values for observed SEDs
+  le (array or list of arrays): emitted wavelength λ_e of SEDs
+  fe (array or list of arrays): emitted function values f_e(λ_e) of SEDs
+  lx (array of float): filter wavelength λ_x
+  Rx (array of float): filter response values R_x(λ_x)
+
+  Returns:
+  array with shape (number of SEDs, number of redshifts)
+  '''
+
   if extinction is not None:
     raise NotImplementedError('cannot handle extinction')
 
@@ -12,7 +25,7 @@ def integrate_sed(z, le, fe, lx, Rx, extinction=None):
 
   lo = np.expand_dims(le, -1)*np.add(z, 1)
   fo = np.expand_dims(fe, -1)
-  Ro = np.apply_along_axis(lambda l: np.interp(l, lx, Rx), -1, lo)
+  Ro = np.apply_along_axis(lambda l: np.interp(l, lx, Rx, left=0., right=0.), -1, lo)
 
   result = np.trapz(lo*fo*Ro, lo, axis=-2)
 

--- a/forward/mag.py
+++ b/forward/mag.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+def integrate_sed(z, λe, fe, λx, Rx, extinction=None):
+  if extinction is not None:
+    raise NotImplementedError('cannot handle extinction')
+
+  if len(np.shape(z)) > 1:
+    raise ValueError('redshift z must be 1d array or scalar')
+
+  if len(np.shape(λx)) != 1 or len(np.shape(Rx)) != 1:
+      raise ValueError('filter λx, Rx must be 1d arrays')
+
+  λo = np.expand_dims(λe, -1)*np.add(z, 1)
+  fo = np.expand_dims(fe, -1)
+  Ro = np.apply_along_axis(lambda λ: np.interp(λ, λx, Rx), -1, λo)
+
+  return np.trapz(λo*fo*Ro, λo, axis=-2)
+

--- a/test/fwtest.py
+++ b/test/fwtest.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+print('add project to python path')
+module_path = os.path.abspath(os.path.join('..'))
+if module_path not in sys.path:
+  sys.path.append(module_path)
+

--- a/test/mag.ipynb
+++ b/test/mag.ipynb
@@ -138,7 +138,7 @@
    "outputs": [],
    "source": [
     "# compute AB magnitudes\n",
-    "m = mag.abmag(z, le, fe, lx, Rx, cosmo)"
+    "m = mag.abmag(z, le, fe, lx, Rx)"
    ]
   },
   {

--- a/test/mag.ipynb
+++ b/test/mag.ipynb
@@ -1,0 +1,202 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.io import fits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import forward test module\n",
+    "import fwtest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load `forward' magnitudes module\n",
+    "from forward import mag"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# the SEDs we want to use\n",
+    "sed_fits = fits.open('k_nmf_derived.default.fits')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# emitted wavelength lambda and SED function f\n",
+    "le = sed_fits[11].data\n",
+    "fe = sed_fits[1].data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# make sure shapes are ok\n",
+    "np.shape(le), np.shape(fe)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# number of SEDs\n",
+    "nsed = np.shape(fe)[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# filter bands to use\n",
+    "bands = 'griz'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# the filters for our instrument\n",
+    "filt_fits = fits.open('STD_BANDPASSES_Y3A2_20170715.fits')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get the filter columns\n",
+    "lx = filt_fits[1].data['LAMBDA']\n",
+    "Rx = [filt_fits[1].data[b] for b in bands]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# redshift range\n",
+    "z = np.linspace(0, 4, 401)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# test the SED integration for many redshifts\n",
+    "# and a single filter\n",
+    "m = mag.integrate_sed(z, le, fe, lx, Rx)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# the shape should be (len(z), len(fe), len(Rx))\n",
+    "np.shape(m)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot the integraded SED values\n",
+    "plt.figure(figsize=(8, 6))\n",
+    "for i, b in enumerate(bands):\n",
+    "    plt.subplot(len(bands)//2, np.ceil(len(bands)/(len(bands)//2)), i+1)\n",
+    "    plt.title(r'${}$-band'.format(b))\n",
+    "    plt.xlabel('$z$')\n",
+    "    plt.ylabel('mag')\n",
+    "    for j in range(nsed):\n",
+    "        plt.plot(z, np.log10(m[:,j,i]))\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/test/mag.ipynb
+++ b/test/mag.ipynb
@@ -25,7 +25,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from astropy.io import fits"
+    "from astropy.io import fits\n",
+    "from astropy.cosmology import Planck15 as cosmo"
    ]
   },
   {
@@ -86,7 +87,7 @@
    "outputs": [],
    "source": [
     "# number of SEDs\n",
-    "nsed = np.shape(fe)[0]"
+    "nsed = len(fe)"
    ]
   },
   {
@@ -127,7 +128,7 @@
    "outputs": [],
    "source": [
     "# redshift range\n",
-    "z = np.linspace(0, 4, 401)"
+    "z = np.arange(0, 4, 0.01)"
    ]
   },
   {
@@ -136,9 +137,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# test the SED integration for many redshifts\n",
-    "# and a single filter\n",
-    "m = mag.integrate_sed(z, le, fe, lx, Rx)"
+    "# compute AB magnitudes\n",
+    "m = mag.abmag(z, le, fe, lx, Rx, cosmo)"
    ]
   },
   {
@@ -165,7 +165,36 @@
     "    plt.xlabel('$z$')\n",
     "    plt.ylabel('mag')\n",
     "    for j in range(nsed):\n",
-    "        plt.plot(z, np.log10(m[:,j,i]))\n",
+    "        plt.plot(z, m[:,j,i])\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# compute colours wrt. to r-band\n",
+    "c = m - m[:,:,[1]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot the colours\n",
+    "plt.figure(figsize=(8, 6))\n",
+    "for i, b in enumerate(bands):\n",
+    "    plt.subplot(len(bands)//2, np.ceil(len(bands)/(len(bands)//2)), i+1)\n",
+    "    plt.title(r'${}-r$-band'.format(b))\n",
+    "    plt.xlabel('$z$')\n",
+    "    plt.ylabel('mag')\n",
+    "    for j in range(nsed):\n",
+    "        plt.plot(z, c[:,j,i])\n",
     "plt.tight_layout()\n",
     "plt.show()"
    ]


### PR DESCRIPTION
The `integrate_sed` function takes an array `z` of redshifts, one or many arrays `λe, fe` that specify SEDs, and a single pair of arrays `λx, Rx` that specifies a filter, and integrates over wavelength.

This can be turned into a magnitude in a second step by the appropriate scaling with the luminosity distance.