### PR TITLE
split magnitude calculation into flux and zeropt

### DIFF
--- a/forward/mag.py
+++ b/forward/mag.py
@@ -80,3 +80,11 @@ def flux(z, le, fe, lx, Rx, extinction=None):
 
   return fluxes
 
+def distmod(z, cosmology):
+  '''Compute the distance modulus at given redshifts.
+
+  The distance of 10pc corresponds to a distance modulus of zero.
+  '''
+
+  return 5*np.log10(cosmology.luminosity_distance(z).value*100 + 1)
+

--- a/forward/mag.py
+++ b/forward/mag.py
@@ -2,24 +2,32 @@ import numpy as np
 import itertools as it
 
 
-def abflux(z, le, fe, lx, Rx, extinction=None):
-  '''AB flux for a single SED and filter at multiple redshifts.
+def integrate_flux(z, le, fe, lx, Rx, extinction=None):
+  '''Integrate flux for a single SED and filter at multiple redshifts.'''
 
-  Does not include the cosmological scaling with luminosity distance.
-  '''
+  if extinction is not None:
+    raise NotImplementedError('cannot handle extinction')
 
   le = np.expand_dims(le, -1)
   fe = np.expand_dims(fe, -1)
   lo = le*(1 + np.atleast_1d(z))
   Ro = np.interp(lo, lx, Rx, left=0, right=0)
 
-  result = np.trapz(lo*fe*Ro, le, axis=-2)/np.trapz(Ro/lo, lo, axis=-2)
+  result = np.trapz(lo*fe*Ro, le, axis=-2)
 
   return result
 
 
-def abmag(z, le, fe, lx, Rx, extinction=None):
-  '''Compute magnitude at source redshifts from SEDs and filters.
+def abzeropt(lx, Rx):
+  '''Get the AB zeropoint magnitudes for given filters.'''
+
+  mag_zero = -2.5*np.log10(np.trapz(Rx/lx, lx, axis=-1))
+
+  return mag_zero
+
+
+def flux(z, le, fe, lx, Rx, extinction=None):
+  '''Compute flux at source redshifts from SEDs and filters.
 
   Does not include the cosmological scaling with (10pc/d_L)^2.
 
@@ -31,11 +39,8 @@ def abmag(z, le, fe, lx, Rx, extinction=None):
   Rx (array or list of arrays): filter response values R_x(λ_x) in counts/photon
 
   Returns:
-  array of shape (#redshifts, #SEDs, #bands) with singular dimensions squeezed
+  array of shape (#redshifts, #SEDs, #bands)
   '''
-
-  if extinction is not None:
-    raise NotImplementedError('cannot handle extinction')
 
   # check input dimensions
   if np.ndim(z) > 1:
@@ -64,7 +69,7 @@ def abmag(z, le, fe, lx, Rx, extinction=None):
   # compute AB fluxes for all bands and SEDs
   fluxes = [
     [
-      abflux(z, le1, fe1, lx1, Rx1, extinction)
+      integrate_flux(z, le1, fe1, lx1, Rx1, extinction)
       for le1, fe1 in zip(le, fe)
     ]
     for lx1, Rx1 in zip(lx, Rx)
@@ -73,8 +78,5 @@ def abmag(z, le, fe, lx, Rx, extinction=None):
   # transpose to get shape (len(z), len(fe), len(Rx)) for easier processing
   fluxes = np.transpose(fluxes)
 
-  # convert fluxes to magnitudes
-  mag = -2.5*np.log10(fluxes)
-
-  return mag
+  return fluxes
 

--- a/test/mag.ipynb
+++ b/test/mag.ipynb
@@ -137,8 +137,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# compute AB magnitudes\n",
-    "m = mag.abmag(z, le, fe, lx, Rx)"
+    "# compute AB zeropoints for filters\n",
+    "m0 = mag.abzeropt(lx, Rx)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# zeropoints should be about 2\n",
+    "m0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# compute fluxes\n",
+    "f = mag.flux(z, le, fe, lx, Rx)"
    ]
   },
   {
@@ -148,7 +168,17 @@
    "outputs": [],
    "source": [
     "# the shape should be (len(z), len(fe), len(Rx))\n",
-    "np.shape(m)"
+    "np.shape(f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# convert fluxes to AB magnitudes\n",
+    "m = -2.5*np.log10(f) - m0"
    ]
   },
   {


### PR DESCRIPTION
This should make it easier to sample, since we need to compute the sum of SEDs,

> f(λ) = ∑ᵢ cᵢ fᵢ(λ)

which makes it awkward to take the logarithm (for magnitudes) before the fluxes are added together.

The normalisation of the integral is done via the new `abzeropt` function, which returns the AB zeropoint magnitude for each individual filter.